### PR TITLE
Abstract GitHub interactions

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,8 @@ environment variables or through a file named
 * **API_URL**: the URL to the API to be queried; update this to
   support GitHub Enterprise (GHE) installations
 * **DELAY**: the number of seconds to delay between each user operation
+* **LOG_LEVEL**: the threshold for displaying log messages
+  10 = Debug, 20 = Info (default), 30 = Warning, 40 = Error, 50 = Critcal
 * **USER_FILTERS**: a JSON object that allows for the filtering of
   users who may be members of the team.
 

--- a/README.md
+++ b/README.md
@@ -6,6 +6,11 @@ will query GitHub for the list of members of the
 organization and add them to a team under that
 organization.
 
+* **NOTE**: This tool does not modify organizational membership,
+  nor does it change any settings for any repository.  It
+  only affects the one team that's specified and its
+  membership.
+
 ## Reason for this tool
 
 Access to repositories can be provided to individual
@@ -18,6 +23,14 @@ open-source" or
 resources.  This tool fills in the gap -- the
 missing ability to specify organization-wide
 access -- by creating a team that may be used.
+
+Also, for organizations using GitHub Enterprise Cloud
+(GHEC), there exists
+[native functionality](https://docs.github.com/en/enterprise-cloud@latest/organizations/organizing-members-into-teams/synchronizing-a-team-with-an-identity-provider-group)
+for synchronizing team membership with a supported
+Identity Provider (IdP).  The native functionality
+would likely represent a better approach than using
+this tool.
 
 ## Installing the tool
 

--- a/env.sample
+++ b/env.sample
@@ -11,3 +11,24 @@ PAT=ghp_....
 # users to determine if they should be allowed in to
 # a group or if they should be excluded
 USER_FILTERS='{"login": {"reject": [ "^w" ], "allow": [ "n$" ] }}'
+
+# the level for which events are logged with lower numbers meaning
+# more verbosity
+#
+# DEBUG: 10
+# INFO: 20 (default)
+# WARNING: 30
+# ERROR: 40
+# CRITICAL: 50
+LOG_LEVEL = 20
+
+# If DRY_RUN is false, perform read/write operations; otherwise
+# only perform read-only operations
+DRY_RUN = True
+
+# The URL to the API; the default is the URL to GitHub.com's API
+# (note the absence of a trailing '/')
+API_URL = https://api.github.com
+
+# How many seconds to delay between API calls
+DELAY = 3.0

--- a/sync.py
+++ b/sync.py
@@ -33,12 +33,12 @@ load_dotenv()
 ##
 # @var str PAT
 # @brief Personal Access Token for interacting with GitHub
-PAT = os.getenv("PAT", None)
+PAT = str(os.getenv("PAT", None))
 
 ##
 # @var str ORG
 # @brief name of GitHub organization to query
-ORG = os.getenv("ORG", None)
+ORG = str(os.getenv("ORG", None))
 
 ##
 # @var str TEAM_NAME


### PR DESCRIPTION
This will add a layer of abstraction around the GitHub API interactions
that write to the API (i.e., stuff affected by `DRY_RUN`.  This helps
test the tool without actually writing to GitHub.

An additional logging variable was added, `LOG_LEVEL` that allows the
user to specify how verbose (higher = less verbose) the tool will be
when determing which messages to display.  The default is 20 (i.e.,
INFO); 10 would correspond to DEBUG while 50 would correspond to
CRITICAL.

The documentation and sample env file were updated.